### PR TITLE
Fix signup controller: validation, JWT_SECRET check, duplicate email handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -505,6 +505,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -15,27 +15,27 @@ export const signupUser = async (req, res) => {
         const hasValidPassword = isNonEmptyString(password);
 
         if (!hasValidName || !hasValidEmail || !hasValidPassword) {
-            return res.status(400).json({ message: 'Name, email, and password must be non-empty strings.' });
+            return res.status(400).json({ error: 'Name, email, and password must be non-empty strings.' });
         }
 
         if (password.length < 8) {
-            return res.status(400).json({ message: 'Password must be at least 8 characters long.' });
+            return res.status(400).json({ error: 'Password must be at least 8 characters long.' });
         }
 
         const sanitizedEmail = typeof email === 'string' ? normalizeEmail(email) : '';
         if (!isValidEmailFormat(sanitizedEmail)) {
-            return res.status(400).json({ message: 'Please provide a valid email address.' });
+            return res.status(400).json({ error: 'Please provide a valid email address.' });
         }
 
         const jwtSecret = process.env.JWT_SECRET;
         if (!jwtSecret) {
             console.error('JWT_SECRET is not configured.');
-            return res.status(500).json({ message: 'Server configuration error.' });
+            return res.status(500).json({ error: 'Server configuration error.' });
         }
 
         const existingUser = await User.findOne({ email: sanitizedEmail });
         if (existingUser) {
-            return res.status(409).json({ message: 'An account with this email already exists.' });
+            return res.status(409).json({ error: 'An account with this email already exists.' });
         }
 
         const hashedPassword = await bcrypt.hash(password, 10);
@@ -71,9 +71,9 @@ export const signupUser = async (req, res) => {
         });
     } catch (error) {
         if (error && (error.code === 11000 || error.code === 11001)) {
-            return res.status(409).json({ message: 'An account with this email already exists.' });
+            return res.status(409).json({ error: 'An account with this email already exists.' });
         }
         console.error('Error during user signup:', error);
-        return res.status(500).json({ message: 'Failed to register user.' });
+        return res.status(500).json({ error: 'Failed to register user.' });
     }
 };

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,0 +1,66 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const normalizeEmail = (rawEmail = '') => rawEmail.trim().toLowerCase();
+
+export const signupUser = async (req, res) => {
+    try {
+        const { name, email, password, role } = req.body || {};
+
+        if (!name || !email || !password) {
+            return res.status(400).json({ message: 'Name, email, and password are required.' });
+        }
+
+        if (password.length < 8) {
+            return res.status(400).json({ message: 'Password must be at least 8 characters long.' });
+        }
+
+        const sanitizedEmail = normalizeEmail(email);
+
+        const existingUser = await User.findOne({ email: sanitizedEmail });
+        if (existingUser) {
+            return res.status(409).json({ message: 'An account with this email already exists.' });
+        }
+
+        const hashedPassword = await bcrypt.hash(password, 10);
+
+        const selectedRole = ['student', 'teacher', 'admin'].includes(role) ? role : undefined;
+
+        const user = await User.create({
+            name: name.trim(),
+            email: sanitizedEmail,
+            password: hashedPassword,
+            role: selectedRole || undefined,
+        });
+
+        const jwtSecret = process.env.JWT_SECRET;
+        if (!jwtSecret) {
+            console.error('JWT_SECRET is not configured.');
+            return res.status(500).json({ message: 'Server configuration error. Please contact support.' });
+        }
+
+        const token = jwt.sign(
+            { userId: user._id, role: user.role },
+            jwtSecret,
+            { expiresIn: '7d' }
+        );
+
+        return res.status(201).json({
+            message: 'User registered successfully.',
+            user: {
+                id: user._id,
+                name: user.name,
+                email: user.email,
+                role: user.role,
+                points: user.points,
+                coins: user.coins,
+                level: user.level,
+            },
+            token,
+        });
+    } catch (error) {
+        console.error('Error during user signup:', error);
+        return res.status(500).json({ message: 'Failed to register user.', error: error.message });
+    }
+};

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -4,6 +4,7 @@ import User from '../models/User.js';
 
 const normalizeEmail = (rawEmail = '') => rawEmail.trim().toLowerCase();
 const isNonEmptyString = (value) => typeof value === 'string' && value.trim().length > 0;
+const isValidEmailFormat = (value = '') => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 
 export const signupUser = async (req, res) => {
     try {
@@ -11,20 +12,26 @@ export const signupUser = async (req, res) => {
 
         const hasValidName = isNonEmptyString(name);
         const hasValidEmail = isNonEmptyString(email);
-        const hasValidPassword = typeof password === 'string' && password.trim().length > 0;
+        const hasValidPassword = isNonEmptyString(password);
 
         if (!hasValidName || !hasValidEmail || !hasValidPassword) {
-            return res.status(400).json({ message: 'Name, email, and password are required.' });
+            return res.status(400).json({ message: 'Name, email, and password must be non-empty strings.' });
         }
 
-        if (typeof password !== 'string') {
-            return res.status(400).json({ message: 'Password must be a string.' });
-        }
         if (password.length < 8) {
             return res.status(400).json({ message: 'Password must be at least 8 characters long.' });
         }
 
-        const sanitizedEmail = normalizeEmail(email);
+        const sanitizedEmail = typeof email === 'string' ? normalizeEmail(email) : '';
+        if (!isValidEmailFormat(sanitizedEmail)) {
+            return res.status(400).json({ message: 'Please provide a valid email address.' });
+        }
+
+        const jwtSecret = process.env.JWT_SECRET;
+        if (!jwtSecret) {
+            console.error('JWT_SECRET is not configured.');
+            return res.status(500).json({ message: 'Server configuration error.' });
+        }
 
         const existingUser = await User.findOne({ email: sanitizedEmail });
         if (existingUser) {
@@ -33,20 +40,15 @@ export const signupUser = async (req, res) => {
 
         const hashedPassword = await bcrypt.hash(password, 10);
 
-        const selectedRole = ['student', 'teacher', 'admin'].includes(role) ? role : undefined;
+        const allowedRoles = ['student', 'teacher'];
+        const selectedRole = allowedRoles.includes(role) ? role : 'student';
 
         const user = await User.create({
             name: name.trim(),
             email: sanitizedEmail,
             password: hashedPassword,
-            role: selectedRole || undefined,
+            role: selectedRole,
         });
-
-        const jwtSecret = process.env.JWT_SECRET;
-        if (!jwtSecret) {
-            console.error('JWT_SECRET is not configured.');
-            return res.status(500).json({ message: 'Server configuration error. Please contact support.' });
-        }
 
         const token = jwt.sign(
             { userId: user._id, role: user.role },
@@ -68,6 +70,9 @@ export const signupUser = async (req, res) => {
             token,
         });
     } catch (error) {
+        if (error && (error.code === 11000 || error.code === 11001)) {
+            return res.status(409).json({ message: 'An account with this email already exists.' });
+        }
         console.error('Error during user signup:', error);
         return res.status(500).json({ message: 'Failed to register user.' });
     }

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -69,6 +69,6 @@ export const signupUser = async (req, res) => {
         });
     } catch (error) {
         console.error('Error during user signup:', error);
-        return res.status(500).json({ message: 'Failed to register user.', error: error.message });
+        return res.status(500).json({ message: 'Failed to register user.' });
     }
 };

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -3,12 +3,17 @@ import jwt from 'jsonwebtoken';
 import User from '../models/User.js';
 
 const normalizeEmail = (rawEmail = '') => rawEmail.trim().toLowerCase();
+const isNonEmptyString = (value) => typeof value === 'string' && value.trim().length > 0;
 
 export const signupUser = async (req, res) => {
     try {
         const { name, email, password, role } = req.body || {};
 
-        if (!name || !email || !password) {
+        const hasValidName = isNonEmptyString(name);
+        const hasValidEmail = isNonEmptyString(email);
+        const hasValidPassword = typeof password === 'string' && password.trim().length > 0;
+
+        if (!hasValidName || !hasValidEmail || !hasValidPassword) {
             return res.status(400).json({ message: 'Name, email, and password are required.' });
         }
 

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -12,6 +12,9 @@ export const signupUser = async (req, res) => {
             return res.status(400).json({ message: 'Name, email, and password are required.' });
         }
 
+        if (typeof password !== 'string') {
+            return res.status(400).json({ message: 'Password must be a string.' });
+        }
         if (password.length < 8) {
             return res.status(400).json({ message: 'Password must be at least 8 characters long.' });
         }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -13,6 +13,6 @@ router.post('/lib-install', installLibrary);
 router.get('/lib-list', listLibraries);
 
 // Authentication
-router.post('/auth/signup', signupUser);
+router.post('/signup', signupUser);
 
 export default router;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -2,6 +2,7 @@ import express from 'express';
 const router = express.Router();
 import { compileArduinoCode } from '../controllers/compileController.js';
 import { searchLibrary, installLibrary, listLibraries } from '../controllers/libController.js';
+import { signupUser } from '../controllers/authController.js';
 
 // Compile Arduino code
 router.post('/compile', compileArduinoCode);
@@ -10,5 +11,8 @@ router.post('/compile', compileArduinoCode);
 router.get('/lib-search', searchLibrary);
 router.post('/lib-install', installLibrary);
 router.get('/lib-list', listLibraries);
+
+// Authentication
+router.post('/auth/signup', signupUser);
 
 export default router;


### PR DESCRIPTION
Implemented /api/signup endpoint that validates trimmed name, email, and password.

Enforces minimum password length and checks email format.

Rejects duplicate emails with a 409 Conflict response.

Restricts self-assigned roles to student or teacher, defaulting to student.

Ensures JWT_SECRET is present before creating users.

Successful signups store hashed passwords, create the User document, and return profile metadata along with a 7-day JWT.

Error responses ({ error: ... }) are consistent with existing controllers.