### PR TITLE
feat(auth): role-selection via Google OAuth state param

### DIFF
--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -12,37 +12,55 @@ if (googleClientId && googleClientSecret &&
             {
                 clientID: googleClientId,
                 clientSecret: googleClientSecret,
-                callbackURL: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:5000/auth/google/callback',
+                callbackURL: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:5001/auth/google/callback',
+                // Pass the request object to the verify callback so we can read oauthState
+                passReqToCallback: true,
             },
-            async (accessToken, refreshToken, profile, done) => {
+            async (req, accessToken, refreshToken, profile, done) => {
                 try {
-                    // Find existing user by Google ID or by the email they registered with previously
+                    const email = profile.emails[0].value;
+
+                    // Find existing user by Google ID or by email
                     let user = await User.findOne({
                         $or: [
                             { googleId: profile.id },
-                            { email: profile.emails[0].value }
+                            { email },
                         ]
                     });
 
                     if (user) {
-                        // If user exists but doesn't have a googleId (they registered manually first)
+                        // Existing user — link their Google ID if not already linked
                         if (!user.googleId) {
                             user.googleId = profile.id;
                             await user.save();
                         }
+                        // Never overwrite an existing user's role on login
                         return done(null, user);
                     }
 
-                    // If not found, create a new user
+                    // ── New user ──────────────────────────────────────────────
+                    // Read the state that was attached in the callback route
+                    const state = req.oauthState || {};
+                    const allowedRoles = ['student', 'teacher'];
+                    const role = allowedRoles.includes(state.role) ? state.role : 'student';
+
+                    // Google provides name, email, and picture — use picture as default image
+                    const picture = profile.photos?.[0]?.value || '';
+
                     user = await User.create({
                         googleId: profile.id,
                         name: profile.displayName,
-                        email: profile.emails[0].value,
+                        email,
+                        role,
+                        image: picture,
+                        // Optional fields from state (student-specific)
+                        ...(state.college && { college: state.college }),
+                        ...(state.semester && { semester: state.semester }),
                     });
 
-                    done(null, user);
+                    return done(null, user);
                 } catch (err) {
-                    done(err, null);
+                    return done(err, null);
                 }
             }
         )
@@ -50,7 +68,7 @@ if (googleClientId && googleClientSecret &&
     console.log('✅ Google OAuth strategy registered');
 } else {
     console.warn('⚠️  Google OAuth credentials not configured — /auth/google routes will be unavailable');
-    console.warn('   Add GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to your .env file');
+    console.warn('   Add GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to your env file');
 }
 
 passport.serializeUser((user, done) => {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -5,16 +5,92 @@ import { protectRoute } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
-// 1. Initiate Google Login (redirects the browser to Google)
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const ALLOWED_ROLES = ['student', 'teacher'];
+
+/**
+ * Encode arbitrary data into a base64 string to use as OAuth `state`.
+ * We also embed a random nonce so the state can't be replayed.
+ */
+function encodeState(data) {
+    return Buffer.from(JSON.stringify({
+        ...data,
+        _nonce: Math.random().toString(36).slice(2),
+    })).toString('base64url');
+}
+
+function decodeState(raw) {
+    try {
+        return JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
+    } catch {
+        return null;
+    }
+}
+
+// ─── Routes ──────────────────────────────────────────────────────────────────
+
+// 1. Simple Google Login (no role — for returning users)
+//    The Passport strategy will keep the user's existing role.
 router.get(
     '/google',
-    passport.authenticate('google', { scope: ['profile', 'email'] })
+    passport.authenticate('google', {
+        scope: ['profile', 'email'],
+        state: encodeState({ intent: 'login' }),
+    })
 );
 
-// 2. Google OAuth Callback (Google redirects back here after user consents)
+/**
+ * 2. Google Sign-Up with role selection
+ *
+ *    Frontend should redirect the user to:
+ *      GET /auth/google/signup?role=student      (student sign-up)
+ *      GET /auth/google/signup?role=teacher      (teacher sign-up)
+ *
+ *    Optional for students (include in query params to pre-fill):
+ *      &college=IIT+Bombay
+ *      &semester=3
+ *
+ *    The role (and optional fields) are encoded in the OAuth `state`
+ *    parameter so Google passes them back unchanged in the callback.
+ */
+router.get('/google/signup', (req, res, next) => {
+    const { role, college, semester } = req.query;
+
+    if (!ALLOWED_ROLES.includes(role)) {
+        return res.status(400).json({
+            error: `Invalid role. Must be one of: ${ALLOWED_ROLES.join(', ')}`,
+        });
+    }
+
+    const statePayload = {
+        intent: 'signup',
+        role,
+        // Optional fields — only attached if provided
+        ...(college && { college }),
+        ...(semester && !isNaN(Number(semester)) && { semester: Number(semester) }),
+    };
+
+    passport.authenticate('google', {
+        scope: ['profile', 'email'],
+        state: encodeState(statePayload),
+    })(req, res, next);
+});
+
+
+// 3. Google OAuth Callback — handles both login and signup
 router.get(
     '/google/callback',
-    passport.authenticate('google', { failureRedirect: process.env.FRONTEND_URL || 'http://localhost:5173' }),
+    (req, res, next) => {
+        // Decode and attach state to request BEFORE passport processes it
+        const raw = req.query.state;
+        if (raw) req.oauthState = decodeState(raw);
+        next();
+    },
+    passport.authenticate('google', {
+        failureRedirect: process.env.FRONTEND_URL || 'http://localhost:5173',
+        session: false,
+    }),
     (req, res) => {
         // Generate a JWT for our application
         const token = jwt.sign(
@@ -24,15 +100,12 @@ router.get(
         );
 
         const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
-
-        // Redirect to the frontend and pass the token as a URL parameter
-        // Your frontend should read this from the URL, save it, and then clear the URL
         res.redirect(`${frontendUrl}?token=${token}`);
     }
 );
 
-// 3. Get current authenticated user
-// Frontend hits this with "Authorization: Bearer <token>" to get profile
+// 4. Get current authenticated user
+//    Frontend hits this with "Authorization: Bearer <token>" to get profile
 router.get('/me', protectRoute, (req, res) => {
     res.json({ success: true, user: req.user });
 });


### PR DESCRIPTION
- Add GET /auth/google/signup?role=student|teacher for new users
  - Encodes role + optional college/semester in base64 OAuth state
  - Validates role before initiating the OAuth redirect
- Keep GET /auth/google for returning users (no role change)
- Update passport.js with passReqToCallback:true to read oauthState
  - New users get role, college, semester from state
  - Google profile picture saved as user image
  - Existing users role is NEVER overwritten on login
- Frontend team: point sign-up buttons at /auth/google/signup?role=<role>