### PR TITLE
fix: resolve WDT shim conflicts and remove Blynk from library cache

### DIFF
--- a/src/config/libraries.json
+++ b/src/config/libraries.json
@@ -23,7 +23,5 @@
         "LiquidCrystal",
         "OneWire"
     ],
-    "cached": [
-        "Blynk@1.3.5"
-    ]
+    "cached": []
 }

--- a/src/esp32/utils/SimulatorBridge.h
+++ b/src/esp32/utils/SimulatorBridge.h
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * SimulatorBridge.h    ESP32 QEMU GPIO + Serial Shim  (v3.0  stable)
  * 
  * Injected at compile time by compileController.js.
@@ -181,13 +181,22 @@ void _simBridgeInit_Late();
 #  define heap_caps_free(p)             free(p)
 #endif
 
-// ── Watchdog shims ───────────────────────────────────────────────────────────
-// WDT is already disabled in _simBridgeInit_Early; stubs prevent linker errors
-#define esp_task_wdt_init(timeout,panic)  ((void)0)
-#define esp_task_wdt_deinit()             ((void)0)
-#define esp_task_wdt_add(task)            ((void)0)
-#define esp_task_wdt_delete(task)         ((void)0)
-#define esp_task_wdt_reset()              ((void)0)
+// ── Watchdog shims ─────────────────────────────────────────────────────────
+// Include esp_task_wdt.h first so its typed function declarations are
+// processed before our no-op macros override them.
+#if __has_include("esp_task_wdt.h")
+#  include "esp_task_wdt.h"
+#endif
+#undef  esp_task_wdt_init
+#undef  esp_task_wdt_deinit
+#undef  esp_task_wdt_add
+#undef  esp_task_wdt_delete
+#undef  esp_task_wdt_reset
+#define esp_task_wdt_init(...)    ((void)0)
+#define esp_task_wdt_deinit(...)  ((void)0)
+#define esp_task_wdt_add(...)     ((void)0)
+#define esp_task_wdt_delete(...)  ((void)0)
+#define esp_task_wdt_reset(...)   ((void)0)
 
 // ── RTC memory attribute ─────────────────────────────────────────────────────
 // In simulation, RTC_DATA_ATTR variables are just normal static variables.

--- a/src/stm32/utils/STM32SimulatorBridge.h
+++ b/src/stm32/utils/STM32SimulatorBridge.h
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * STM32SimulatorBridge.h    STM32 Renode GPIO + Serial Shim
  * 
  * Injected at compile time by compileController.js.
@@ -82,6 +82,10 @@ extern "C" {
     void sim_tone(uint32_t pin, unsigned int frequency, unsigned long duration = 0);
     void sim_noTone(uint32_t pin);
 }
+
+// STM32 core v3.x Tone.cpp defines noTone(pin,bool) which expands to sim_noTone(pin,bool).
+// Forward-declare the 2-arg overload here so the 1-arg version can call it.
+void sim_noTone(uint8_t pin, bool destruct);
 
 #undef  pinMode
 #undef  digitalRead


### PR DESCRIPTION
- esp32/SimulatorBridge.h: Refactor watchdog (WDT) shims to include esp_task_wdt.h before applying no-op macros, preventing redefinition conflicts with typed function declarations in the ESP-IDF header. Updated all WDT macros to use variadic args (...) for broader compatibility.
- stm32/STM32SimulatorBridge.h: Forward-declare the 2-arg overload of sim_noTone() to fix linker conflicts introduced by STM32 core v3.x Tone.cpp defining noTone(pin, bool).
- config/libraries.json: Clear the cached library list, removing Blynk@1.3.5 from pre-cached dependencies.